### PR TITLE
SCA tutorial fixes (mobile)

### DIFF
--- a/docs/tutorials/Mobile-First-Authentication/Android-Tutorial.md
+++ b/docs/tutorials/Mobile-First-Authentication/Android-Tutorial.md
@@ -42,7 +42,7 @@ The easiest way to install the PowerAuth SDK into your project is from JCenter. 
 {% codetab Gradle %}
 ```groovy
 repositories {
-    mavenCentral() # if not defined elsewhere...
+    mavenCentral() // if not defined elsewhere...
 }
 
 dependencies {

--- a/docs/tutorials/Mobile-First-Authentication/Android-Tutorial.md
+++ b/docs/tutorials/Mobile-First-Authentication/Android-Tutorial.md
@@ -1,4 +1,4 @@
-# Implementing Authentication in Mobile Banking Apps (SCA) on Android Platform
+# Implementing Authentication in Mobile Banking Apps (SCA) on the Android Platform
 
 <!-- AUTHOR joshis_tweets 2020-05-04T00:00:00Z -->
 <!-- SIDEBAR _Sidebar_Android.md sticky -->
@@ -15,11 +15,11 @@ This tutorial has four parts:
 
 ## Prerequisites
 
-This tutorial assumes, that you have:
+This tutorial assumes that you have:
 
 - Read and understood the [Mobile Authentication Overview](Readme.md)
 - [Required back-end infrastructure up and running](Server-Side-Tutorial.md).
-- Android Studio and Android SDK (API level 16+).
+- Android Studio and Android SDK (API level 21+).
 
 ## Introduction
 
@@ -28,9 +28,9 @@ When implementing the authentication flow on mobile, your task consists of build
 - Device activation
 - Transaction signing
 
-Of course, you will need to also implement several auxiliary use-cases but these will become simple once you have device activation and transaction signing use-cases in place.
+Of course, you will also need to implement several auxiliary use-cases, but these will become simple once you have device activation and transaction signing use-cases in place.
 
-Our [Mobile Security Suite SDK](https://wultra.com/mobile-security-suite) will help you with the above-mentioned use-cases. Since the underlying authentication protocol is called PowerAuth, the Mobile Security Suite SDK technical components inherit this naming. The "Mobile Security Suite SDK" is called the **PowerAuth SDK** on the technical level.
+Our [Mobile Security Suite SDK](https://wultra.com/mobile-security-suite) will help you with the above-mentioned use cases. Since the underlying authentication protocol is called PowerAuth, the Mobile Security Suite SDK technical components inherit this naming. The "Mobile Security Suite SDK" is called the **PowerAuth SDK** on the technical level.
 
 During the device activation flow, the SDK communicates with the public enrollment services. During the transaction signing, the SDK communicates with your server that publishes some protected resources (login, payment approval). The mobile app never communicates with the PowerAuth Server interface since this component is hidden deep in the secure infrastructure. See the component description in the [introductory overview documentation](Readme.md).
 
@@ -40,89 +40,81 @@ The easiest way to install the PowerAuth SDK into your project is from JCenter. 
 
 {% codetabs %}
 {% codetab Gradle %}
-```rb
+```groovy
 repositories {
-    jcenter() # if not defined elsewhere...
+    mavenCentral() # if not defined elsewhere...
 }
 
 dependencies {
-    compile 'io.getlime.security.powerauth:powerauth-android-sdk:1.3.3'
+    compile 'io.getlime.security.powerauth:powerauth-android-sdk:1.9.4'
 }
 ```
 {% endcodetab %}
 {% endcodetabs %}
 
-_Note: We use 1.3.3 in the example, replace the version number with the [latest release](https://github.com/wultra/powerauth-mobile-sdk/releases)._
+_Note: We use 1.9.4 in the example, replace the version number with the [latest release](https://github.com/wultra/powerauth-mobile-sdk/releases)._
 
 ## Configuration
 
 To configure your `PowerAuthSDK` instance, you need the following values from the PowerAuth Server:
 
-- `APP_KEY` - Application key that binds an activation with a specific application.
-- `APP_SECRET` - Application secret that binds an activation with a specific application.
-- `KEY_MASTER_SERVER_PUBLIC` - Master Server Public Key used for non-personalized encryption and server signature verification.
-- `BASE_ENDPOINT_URL` - The location of your [PowerAuth Standard RESTful API](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Standard-RESTful-API.md) endpoints. The path should contain everything that goes before the `/pa/**` prefix of the API endpoints.
+- `MOBILE_SDK_CONFIG ` - Base64 string with the cryptographic configuration.
+- `BASE_ENDPOINT_URL` - The location of your [PowerAuth Standard RESTful API](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Standard-RESTful-API.md) endpoints. The path should contain everything that goes before the `/pa/**` prefix of the API endpoints (usually _https://***/enrollment-server_)
 
-All these values should be provided to you by your [server-side team](Server-Side-Tutorial.md) who configured the back-end infrastructure.
+All these values should be provided to you by your [server-side team](Server-Side-Tutorial.md), who configured the back-end infrastructure.
 
 Use the provided values to configure the `PowerAuthSDK` instance:
 
 {% codetabs %}
-{% codetab Java %}
-```java
-String INSTANCE_ID = getApplicationContext().getPackageName();
-String PA_APPLICATION_KEY = "sbG8gd...MTIzNA==";
-String PA_APPLICATION_SECRET = "aGVsbG...MTIzNA==";
-String PA_MASTER_SERVER_PUBLIC_KEY = "MTIzNDU2Nz...jc4OTAxMg==";
-String API_SERVER = "https://localhost:8080/demo-server";
+{% codetab Kotlin %}
+```kotlin
+val INSTANCE_ID = applicationContext.packageName
+val MOBILE_SDK_CONFIG = "MTIzNDU2Nz...jc4OTAxMg=="
+val API_SERVER = "https://<your-domain>/enrollment-server"
 
-final PowerAuthConfiguration configuration = new PowerAuthConfiguration.Builder(
+try {
+    val configuration = PowerAuthConfiguration.Builder(
         INSTANCE_ID,
         API_SERVER,
-        PA_APPLICATION_KEY,
-        PA_APPLICATION_SECRET,
-        PA_MASTER_SERVER_PUBLIC_KEY).build();
-
-PowerAuthSDK powerAuthSDK = new PowerAuthSDK.Builder(configuration)
-        .build(getApplicationContext());
+        MOBILE_SDK_CONFIG)
+        .build()
+    val powerAuthSDK = PowerAuthSDK.Builder(configuration)
+        .build(applicationContext)
+} catch (exception: PowerAuthErrorException) {
+    // Failed to construct `PowerAuthSDK` due to insufficient keychain protection.
+    // (See next chapter for details)
+}
 ```
 {% endcodetab %}
 {% endcodetabs %}
 
 <!-- begin box warning -->
-In case you use a development infrastructure with self-signed certificates, make sure to set `PA2ClientSslNoValidationStrategy` instance to networking - see the [reference guide for more details](https://github.com/wultra/powerauth-mobile-sdk/blob/develop/docs/PowerAuth-SDK-for-Android.md#working-with-invalid-ssl-certificates).
+In case you use a development infrastructure with self-signed certificates, make sure to set the `PA2ClientSslNoValidationStrategy` instance to networking - see the [reference guide for more details](https://github.com/wultra/powerauth-mobile-sdk/blob/develop/docs/PowerAuth-SDK-for-Android.md#working-with-invalid-ssl-certificates).
 <!-- end -->
 
 ## Checking the Activation Status
 
-After a user launches an application, you need to determine which user interface to show. Should you display a login UI? Or a new activation flow? Or an information that the device is blocked or removed?
+After a user launches an application, you need to determine which user interface to show. Should you display a login UI? Or a new activation flow? Or is an information that the device is blocked or removed?
 
-Luckily, we have a simple method calls to obtain a detailed activation status:
+Luckily, we have a simple method to obtain a detailed activation status:
 
 {% codetabs %}
-{% codetab Java %}
-```java
+{% codetab Kotlin %}
+```kotlin
 // Check if there is some activation on the device
 if (powerAuthSDK.hasValidActivation()) {
-
     // If there is an activation on the device, check the status with server
-    powerAuthSDK.fetchActivationStatusWithCallback(context, new IActivationStatusListener() {
-        @Override
-        public void onActivationStatusSucceed(ActivationStatus status) {
-            // Show the UI relevant to the activation status.
-            this.presentUiWithStatus(status);
+    powerAuthSDK.fetchActivationStatusWithCallback(context, object: IActivationStatusListener {
+        override fun onActivationStatusSucceed(status: ActivationStatus) {
+            // process the state
         }
 
-        @Override
-        public void onActivationStatusFailed(Throwable t) {
+        override fun onActivationStatusFailed(t: Throwable) {
             // Network error occurred, report it to the user
-            this.presentNetworkError();
         }
-    });
+    })
 } else {
-    // No activation is present on device.
-    // Show the UI for a new activation.
-    this.presentNewActivationUi();
+    // No activation present on device
 }
 ```
 {% endcodetab %}
@@ -136,13 +128,13 @@ Here is an example mockup of the screens that need to be implemented:
 
 ## New Activation
 
-In the case no usable activation is available on the Android device, you can guide the user through the steps to create it. Each activation has two major flows on the mobile device:
+In the case that no usable activation is available on the Android device, you can guide the user through the steps to create it. Each activation has two major flows on the mobile device:
 
 - **Creating the Activation** - Exchanging the user's identity proof with the server for the cryptographic activation data.
-- **Committing the Activation** - Storing the cryptographic activation data on the device using the user's local credentials.
+- **Persisting the Activation** - Storing the cryptographic activation data on the device using the user's local credentials.
 
 <!-- begin box info -->
-Thanks to this step, the user credentials, such as PIN code or biometric information, never leave the mobile device and are only used locally, to obtain cryptographic data required during the transaction signing.
+Thanks to this step, the user credentials, such as PIN code or biometric information, never leave the mobile device and are only used locally to obtain cryptographic data required during the transaction signing.
 <!-- end -->
 
 ### Creating the Activation
@@ -154,39 +146,38 @@ In the first step of a new activation process, you need to exchange the user's p
 The easiest way to create an activation is using the PowerAuth activation code that you will obtain from the back-end part (for example, via a QR code shown in the Internet banking):
 
 {% codetabs %}
-{% codetab Java %}
-```java
-String deviceName = "Petr's Leagoo T5C";
-String activationCode = "VVVVV-VVVVV-VVVVV-VTFVA";
+{% codetab Kotlin %}
+```kotlin
+val deviceName = "Petr's Leagoo T5C"
+val activationCode = "VVVVV-VVVVV-VVVVV-VTFVA" // let user type or QR-scan this value
 
 // Create activation object with given activation code.
-final PowerAuthActivation activation;
+val activation: PowerAuthActivation
 try {
-    activation = PowerAuthActivation.Builder.activation(activationCode, deviceName).build();
-} catch (PowerAuthErrorException e) {
+    activation = PowerAuthActivation.Builder.activation(activationCode, deviceName).build()
+} catch (e: PowerAuthErrorException) {
     // Invalid activation code
 }
 
-// Create a new activation with just created activation object
-powerAuthSDK.createActivation(activation, new ICreateActivationListener() {
-
-    @Override
-    public void onActivationCreateSucceed(CreateActivationResult result) {
-        // No error occurred, proceed to credentials entry (PIN prompt, Enable "Fingerprint Authentication" switch, ...) and commit
+// Create a new activation with the given activation object
+powerAuthSDK.createActivation(activation, object: ICreateActivationListener {
+    override fun onActivationCreateSucceed(result: CreateActivationResult) {
+        val fingerprint = result.activationFingerprint
+        // No error occurred, proceed to credentials entry (PIN prompt, Enable "Fingerprint Authentication" switch, ...) and persist
+        // The 'fingerprint' value represents the combination of device and server public keys - it may be used as visual confirmation
     }
 
-    @Override
-    public void onActivationCreateFailed(Throwable t) {
+    override fun onActivationCreateFailed(t: Throwable) {
         // Error occurred, report it to the user
     }
-});
+})
 ```
 {% endcodetab %}
 {% endcodetabs %}
 
 
 <!-- begin box info -->
-You can let the user scan the activation code from a QR code, to make the process faster and improve the user convenience, but you should also allow the manual entry as a backup.
+You can let the user scan the activation code from a QR code to make the process faster and improve user convenience, but you should also allow manual entry as a backup.
 <!-- end -->
 
 ##### Mockups
@@ -197,45 +188,42 @@ Here is an example mockup of the screens that need to be implemented:
 
 #### Using Custom Credentials
 
-Alternatively, you can use some other credentials your server supports to create a new activation. You always need to spend some thought about which credentials you should use. You do not want to use credentials that are too weak. **The authentication proof resulting from transaction signing is only as strong as the credentials that were used during the activation flow.**
+Alternatively, you can use some other credentials your server supports to create a new activation. You always need to spend some thought on which credentials you should use. You do not want to use credentials that are too weak. **The authentication proof resulting from transaction signing is only as strong as the credentials that were used during the activation flow.**
 
 However, once you have the credentials that are sufficiently strong, you can create an activation easily:
 
 {% codetabs %}
-{% codetab Java %}
-```java
-// Create a new activation with given device name and login credentials
-String deviceName = "Petr's Leagoo T5C";
-Map<String, String> credentials = new HashMap<>();
-credentials.put("username", "john.doe@example.com");
-credentials.put("password", "YBzBEM");
-credentials.put("otp", "072471");
+{% codetab Kotlin %}
+```kotlin
+// Create a new activation with a given device name and login credentials
+val deviceName = "Juraj's JiaYu S3"
+val credentials = mapOf("username" to "john.doe@example.com", "password" to "YBzBEM")
 
-// Create activation object with given credentials.
-final PowerAuthActivation activation;
+// Create an activation object with the given credentials.
+val activation: PowerAuthActivation
 try {
-    activation = PowerAuthActivation.Builder.customActivation(credentials, deviceName).build();
-} catch (PowerAuthErrorException e) {
+    activation = PowerAuthActivation.Builder.customActivation(credentials, deviceName).build()
+} catch (e: PowerAuthErrorException) {
     // Credentials dictionary is empty
 }
 
-// Create a new activation with just created activation object
-powerAuthSDK.createActivation(activation, new ICreateActivationListener() {
-    @Override
-    public void onActivationCreateSucceed(CreateActivationResult result) {
-        // No error occurred, proceed to credentials entry (PIN prompt, Enable "Biometric Authentication" switch, ...) and commit
+// Create a new activation with the given activation object
+powerAuthSDK.createActivation(activation, object: ICreateActivationListener {
+    override fun onActivationCreateSucceed(result: CreateActivationResult) {
+        val fingerprint = result.activationFingerprint
+        // No error occurred, proceed to credentials entry (PIN prompt, Enable "Biometric Authentication" switch, ...) and persist
+        // The 'fingerprint' value represents the combination of device and server public keys - it may be used as visual confirmation
     }
 
-    @Override
-    public void onActivationCreateFailed(Throwable t) {
+    override fun onActivationCreateFailed(t: Throwable) {
         // Error occurred, report it to the user
     }
-});
+})
 ```
 {% endcodetab %}
 {% endcodetabs %}
 
-In the example, we used a combination of the username, password and an OTP generated elsewhere (for example, via a HW token, or delivered via SMS). But any credentials that you determined are suitable for activation will work.
+In the example, we used a combination of the username, password, and an OTP generated elsewhere (for example, via a hardware token or delivered via SMS). But any credentials that you determined are suitable for activation will work.
 
 ##### Mockups
 
@@ -243,53 +231,55 @@ Here is an example mockup of the screens that need to be implemented:
 
 ![ Activation Status Check on iOS ](./05.png)
 
-### Committing the Activation
+### Persisting the Activation
 
-After you successfully perform the steps for creating the activation, you can prompt the user to enter the new local PIN code / password and allow an opt-in for the biometric authentication (of course, [only in the case the device supports biometry](https://github.com/wultra/powerauth-mobile-sdk/blob/develop/docs/PowerAuth-SDK-for-Android.md#biometric-authentication-setup)).
+After you successfully perform the steps for creating the activation, you can prompt the user to enter the new local PIN code / password and allow an opt-in for the biometric authentication (of course, [only in the case the device supports biometrics](https://github.com/wultra/powerauth-mobile-sdk/blob/develop/docs/PowerAuth-SDK-for-Android.md#biometric-authentication-setup)).
 
-You can now commit the newly created activation with the requested authentication factors.
+You can now persist the newly created activation with the requested authentication factors.
 
-#### Committing With Biometry
+#### Persisting With Biometry
 
-In the case user decided to opt-in for the biometry, use the following code:
+In the case the user decides to opt in for the biometry, use the following code:
 
 {% codetabs %}
-{% codetab Java %}
-```java
-// Commit activation using given PIN and ad-hoc generated biometric related key
-powerAuthSDK.commitActivation(context, fragmentManager, "Enable Biometric Authentication", "To enable biometric authentication, use the biometric sensor on your device.", pin, new ICommitActivationWithBiometryListener() {
-    @Override
-    public void onBiometricDialogCancelled() {
-        // Biometric enrolment cancelled by user
+{% codetab Kotlin %}
+```kotlin
+// Persist activation using given PIN
+val authentication = PowerAuthAuthentication.persistWithPassword(pin)
+val cancelable = powerAuthSDK.persistActivationWithAuthentication(context, authentication, object: IPersistActivationListener {
+    override fun onPersistActivationSucceeded() {
+        // Success
     }
 
-    @Override
-    public void onBiometricDialogSuccess() {
-        // success, activation has been committed
+    override fun onPersistActivationFailed(error: PowerAuthErrorException) {
+        // Failure
     }
 
-    @Override
-    public void onBiometricDialogFailed(PowerAuthErrorException error) {
-        // failure, typically as a result of API misuse, or a biometric authentication failure
+    override fun onPersistActivationCancelled(userCancel: Boolean) {
+        if (userCancel) {
+            // user cancelled the biometric authentication dialog
+        } else {
+            // Your application canceled the provided cancelable object
+        }
     }
-});
+})
 ```
 {% endcodetab %}
 {% endcodetabs %}
 
-Note that we automatically handle the selection of the appropriate biometric approach. We use [Unified biometric authentication dialog](https://developer.android.com/about/versions/pie/android-9.0#biometric-auth) if available and we fall-back to the fingerprint authentication on older devices or devices that are known to have issues with the newer biometry approaches.
+Note that we automatically handle the selection of the appropriate biometric approach. We use [Unified biometric authentication dialog](https://developer.android.com/about/versions/pie/android-9.0#biometric-auth) if available, and we fall back to the fingerprint authentication on older devices or devices that are known to have issues with the newer biometric approaches.
 
-#### Committing Without Biometry
+#### Persisting Without Biometry
 
-In the case user decided to decline biometry or in the case biometry is not available on the device, you can use this simpler call:
+In the case the user decides to decline biometry or in the case biometry is not available on the device, you can use this simpler call:
 
 {% codetabs %}
-{% codetab Java %}
-```java
-// Commit activation using given PIN
-int result = powerAuthSDK.commitActivationWithPassword(context, pin);
-if (result != PowerAuthErrorCodes.PA2Succeed) {
-    // happens only in case SDK was not configured or activation is not in state to be committed
+{% codetab Kotlin %}
+```kotlin
+// persist activation using given PIN
+val result = powerAuthSDK.persistActivationWithPassword(appContext, pin)
+if (result != PowerAuthErrorCodes.SUCCEED)
+    // happens only in case the SDK was not configured or activation is not in a state to be persisted
 }
 ```
 {% endcodetab %}
@@ -299,19 +289,19 @@ if (result != PowerAuthErrorCodes.PA2Succeed) {
 
 In case you successfully activated the device, you can use the new activation for transaction signing. This is achieved by signing the full request data. In case of the HTTP request with a body (`POST`, `PUT`, `DELETE`), the HTTP request body is used. In case of the `GET` request, the SDK builds canonical data from the URL query parameters.
 
-The transaction signing requires an absolute precision. Every single bit makes a huge difference just one step further in the process. Be patient and do not worry if transaction signing doesn't work the first time you try. In case you are having issues, do not hesitate to ask our engineers for help.
+The transaction signing requires absolute precision. Every single bit makes a huge difference, just one step further in the process. Be patient and do not worry if transaction signing doesn't work the first time you try. In case you are having issues, do not hesitate to ask our engineers for help.
 
 ### User Experience Perspective
 
-To make the user experience consistent, we recommend making a solid UI abstraction on top of the transaction signing logic. This usually means implementing the transaction signing logic inside a **unified PIN keyboard**. Such keyboard would then handle the typical use-cases people expect to see when working with PIN keyboards, such as:
+To make the user experience consistent, we recommend making a solid UI abstraction on top of the transaction signing logic. This usually means implementing the transaction signing logic inside a **unified PIN keyboard**. Such a keyboard would then handle the typical use-cases people expect to see when working with PIN keyboards, such as:
 
 - Entering a PIN code for the purpose of transaction signing.
-- Allowing to use biometry as a faster alternative to the PIN code.
+- Allowing to use of biometrics as a faster alternative to the PIN code.
 - Checking the number of remaining authentication attempts.
 - Showing the transaction signing progress.
 - Error reporting, invalid activation status handling, etc.
 
-The following picture shows an anatomy of a well-designed PIN keyboard:
+The following picture shows the anatomy of a well-designed PIN keyboard:
 
 ![ Anatomy of a PIN keyboard ](./06.png)
 
@@ -325,53 +315,63 @@ You can read more information about the authentication flow in the chapters belo
 
 To cover the typical use-cases efficiently, the unified PIN keyboard should be configurable with at least the following attributes:
 
-- **The URI Address** - Basically the service location that will be called while sending the signed request using an HTTP client of your choice. We use `uri` variable in the example.
+- **The URI Address** - Basically, the service location that will be called while sending the signed request using an HTTP client of your choice. We use the `uri` variable in the example.
 - **The URI ID** - Identifier of the URI / service. **Be very careful here!** In the examples below, we use a value of `uriId` for this value. While it is remarkably similar to the end of an actual URI (`uri`), this value is in fact an arbitrarily chosen constant that the client and server must agree on beforehand for a particular server-side operation represented. You need to ask your server developer for the exact value.
 - **The HTTP request data** - This is basically the data that will be signed. For the `POST` requests (that are the most common in the case of transaction signing), this value represents simply the HTTP request body bytes.
-- **The HTTP method** - (Optional) The HTTP method to be used for the call. For the most cases, the calls should be made via the `POST` value and hence the `POST` value should be the default.
+- **The HTTP method** - (Optional) The HTTP method to be used for the call. In most cases, the calls should be made via the `POST` value, and hence, the `POST` value should be the default.
 - **The HTTP headers** - (Optional) Value of any other HTTP headers you need to use when calling your service.
 
 ### Checking the Activation Status Before Signing
 
-We covered a similar use-case earlier in the context of the new activation flow. However, you should also check for the activation status before every attempt to use the transaction signing since the activation might have been blocked or removed on the server side.
+We covered a similar use case earlier in the context of the new activation flow. However, you should also check for the activation status before every attempt to use the transaction signing, since the activation might have been blocked or removed on the server side.
 
 In case you check the activation status and the result is anything else than `State_Active`, you should cancel the transaction signing flow and redirect the user to the appropriate alternate flow, such as a new activation wizard, unblocking tutorial, etc.
 
-For the `State_Active` status, you should check if the number of failed attempts is greater than zero and show the UI for the number of remaining attempts in such case. The outline of the logic is the following:
+For the `State_Active` status, you should check if the number of failed attempts is greater than zero and show the UI for the number of remaining attempts in such a case. The outline of the logic is the following:
 
 {% codetabs %}
-{% codetab Java %}
-```java
+{% codetab Kotlin %}
+```kotlin
 // Check if there is some activation on the device
 if (powerAuthSDK.hasValidActivation()) {
-
     // If there is an activation on the device, check the status with server
-    powerAuthSDK.fetchActivationStatusWithCallback(context, new IActivationStatusListener() {
-        @Override
-        public void onActivationStatusSucceed(ActivationStatus status) {
-            if (ActivationStatus.State_Active.equals(status.state)) {
-                if (status.failCount > 0) {
-                    this.showRemainingLabel(status.getRemainingAttempts());
-                } else {
-                    this.hideRemainingLabel();
+    powerAuthSDK.fetchActivationStatusWithCallback(context, object: IActivationStatusListener {
+        override fun onActivationStatusSucceed(status: ActivationStatus) {
+            // Activation states are explained in detail in "Activation states" chapter below
+            when (status.state) {
+                ActivationStatus.State_Pending_Commit ->
+                    Log.i(TAG, "Waiting for commit")
+                ActivationStatus.State_Active ->
+                    Log.i(TAG, "Activation is active")
+                ActivationStatus.State_Blocked ->
+                    Log.i(TAG, "Activation is blocked")
+                ActivationStatus.State_Removed -> {
+                    Log.i(TAG, "Activation is no longer valid")
+                    powerAuthSDK.removeActivationLocal(context)
                 }
-                // ... see determining the biometry status
-            } else {
-                // Show the UI relevant to the activation status.
-                this.presentUiWithStatus(status)
+                ActivationStatus.State_Deadlock -> {
+                    Log.i(TAG, "Activation is technically blocked")
+                    powerAuthSDK.removeActivationLocal(context)
+                }
+                ActivationStatus.State_Created -> Log.i(TAG, "Unknown state")
+                else -> Log.i(TAG, "Unknown state")
+            }
+
+            // Failed login attempts, remaining = max - current
+            val currentFailCount: Int = status.failCount
+            val maxAllowedFailCount: Int = status.maxFailCount
+            val remainingFailCount: Int = status.remainingAttempts
+            if (status.customObject != null) {
+                // Custom object contains any proprietary server-specific data
             }
         }
 
-        @Override
-        public void onActivationStatusFailed(Throwable t) {
+        override fun onActivationStatusFailed(t: Throwable) {
             // Network error occurred, report it to the user
-            this.presentNetworkError();
         }
-    });
+    })
 } else {
-    // No activation is present on device.
-    // Show the UI for a new activation.
-    this.presentNewActivationUi();
+    // No activation present on device
 }
 ```
 {% endcodetab %}
@@ -384,99 +384,87 @@ In case the biometry is present and allowed by the user, you should trigger tran
 To check the status of the biometry, you can use the following logic:
 
 {% codetabs %}
-{% codetab Java %}
-```java
-if (BiometricAuthentication.isBiometricAuthenticationAvailable(context) && status.getRemainingAttempts() > 2 && this.autoTriggerBiometry) {
-    this.enableBiometryButton(true);
-    this.signWithBiometry();
+{% codetab Kotlin %}
+```kotlin
+if (BiometricAuthentication.isBiometricAuthenticationAvailable(context) && status.remainingAttempts > 2 && this.autoTriggerBiometry) {
+    this.enableBiometryButton(true)
+    this.signWithBiometry()
 } else {
-    // Let user enter PIN code
-    this.enableBiometryButton(false);
+    // Let the user enter the PIN code
+    this.enableBiometryButton(false)
 }
-this.autoTriggerBiometry = false;
+this.autoTriggerBiometry = false
 ```
 {% endcodetab %}
 {% endcodetabs %}
 
-Note that decided to not only check for the mere availability of the biometry, but we also check for the remaining attempt count to make sure the user is not blocked in case of "wet fingers". Also, you can notice the property `autoTriggerBiometry` that we use to automatically launch the biometry only the first time a unified PIN keyboard is opened. For 2nd and further authentication attempts, we want the user to trigger the biometric authentication manually.
+Note that we decided to not only check for the mere availability of the biometry, but we also check for the remaining attempt count to make sure the user is not blocked in case of "wet fingers". Also, you can notice the property `autoTriggerBiometry` that we use to automatically launch the biometry only the first time a unified PIN keyboard is opened. For 2nd and further authentication attempts, we want the user to trigger the biometric authentication manually.
 
 ### Request Signing
 
 To sign the request data, you first need to prepare a `PowerAuthAuthentication` instance that specifies the authentication factors that you want to use. After that, you can compute the HTTP header with the signature and send the request to the server.
 
 {% codetabs %}
-{% codetab Java %}
-```java
-// Transaction signing with a biometry
-public void signWithBiometry(IMyAuthListener listener) {
-    // Authenticate user with biometry and obtain encrypted biometry factor related key.
-    powerAuthSDK.authenticateUsingBiometry(context, fragmentManager, "Sign in", "Use the biometric sensor on your device to continue", new IBiometricAuthenticationCallback() {
-        @Override
-        public void onBiometricDialogCancelled() {
+{% codetab Kotlin %}
+```kotlin
+// Transaction signing with biometrics
+fun signWithBiometry(listener: IMyAuthListener) {
+    // Authenticate user with biometry and obtain encrypted biometry factor-related key.
+    powerAuthSDK.authenticateUsingBiometrics(context, fragmentManager, "Sign in", "Use the biometric sensor on your device to continue", object: IAuthenticateWithBiometricsListener {
+        override fun onBiometricDialogCancelled(userCancel: Boolean) {
             // User cancelled the operation
             listener.authenticationCancelled();
         }
 
-        @Override
-        public void onBiometricDialogSuccess(@NonNull byte[] encryptedBiometryKey) {
-            // User authenticated and biometry key was returned
-            PowerAuthAuthentication authentication = new PowerAuthAuthentication();
-            authentication.usePossession = true;
-            authentication.useBiometry = encryptedBiometryKey;
+        override fun onBiometricDialogSuccess(authentication: PowerAuthAuthentication) {
             signWithAuthentication(auth, listener);
         }
 
-        @Override
-        public void onBiometricDialogFailed(@NonNull PowerAuthErrorException error) {
-            // Biometric authentication failed
-            listener.authenticationFailed(Reason.BIOMETRY);
+        override fun onBiometricDialogFailed(error: PowerAuthErrorException) {
+            listener.authenticationFailed(error);
         }
-    });
+    })
 }
 
 // Transaction signing with a password or a PIN code
-public void signWithPassword(String password, IMyAuthListener listener) {
-    PowerAuthAuthentication authentication = new PowerAuthAuthentication();
-    authentication.usePossession = true;
-    authentication.usePassword = "1234";
-    return signWithAuthentication(auth, listener)
+fun signWithPassword(password: Password, listener: IMyAuthListener) {
+    val  authentication = PowerAuthAuthentication.possessionWithPassword(password)
+    signWithAuthentication(auth, listener)
 }
 
 // Transaction signing with an authentication object
-public void signWithAuthentication(PowerAuthAuthentication auth, IMyAuthListener listener) {
+fun signWithAuthentication(auth: PowerAuthAuthentication, listener: IMyAuthListener) {
     // Get the request attributes
-    String uri    = this.uri    // "https://my.server.example.com/payment"
-    String uriId  = this.uriId  // "/payment"
-    String method = this.method // "POST"
-    String body   = this.body   // the serialized bytes of HTTP request body
+    val uri    = this.uri    // "https://my.server.example.com/payment"
+    val uriId  = this.uriId  // "/payment"
+    val method = this.method // "POST"
+    val body   = this.body   // the serialized bytes of HTTP request body
 
     // Compute the signature header
-    PowerAuthAuthorizationHttpHeader header = powerAuthSDK.requestSignatureWithAuthentication(context, auth, method, uriId, body);
-    if (!header.isValid()) {
+    val header = powerAuthSDK.requestSignatureWithAuthentication(context, auth, method, uriId, body)
+    if (!header.isValid) {
         listener.authenticationFailed(Reason.CRYPTO);
-        return;
+        return
     }
-    HttpHeader header = new HttpHeader(header.getKey(), header.getValue());
+    val header = HttpHeader(header.key, header.value)
 
     // Send an HTTP request with the HTTP header computed above.
     // Note that we are sending the POST call to the service URI, with
     // a computed signature HTTP header and the request body bytes
-    this.httpClient.post(uri, header, body, new IMyHttpClientListener() {
-        @Override
-        public void networkSuccess(int statusCode, HttpHeader[] headers, byte[] responseBody) {
+    this.httpClient.post(uri, header, body, object: IMyHttpClientListener {
+        fun networkSuccess(statusCode: Int, headers: List<Header>, responseBody: ByteArray) {
             if (statusCode == 200) {
-                listener.authenticationSuccess(headers, responseBody);
+                listener.authenticationSuccess(headers, responseBody)
             } else if (statusCode == 401 || statusCode == 403) {
-                listener.authenticationFailed(Reason.UNAUTHORIZED);
+                listener.authenticationFailed(Reason.UNAUTHORIZED)
             } else {
-                listener.authenticationFailed(Reason.OTHER);
+                listener.authenticationFailed(Reason.OTHER)
             }
         }
 
-        @Override
-        public void networkFailed() {
+        fun networkFailed() {
             // Networking failed
-            listener.authenticationFailed(Reason.NETWORKING);
+            listener.authenticationFailed(Reason.NETWORKING)
         }
     })
 }
@@ -486,11 +474,11 @@ public void signWithAuthentication(PowerAuthAuthentication auth, IMyAuthListener
 
 You can hook the `signWithBiometry` method to the button for the biometric authentication and the `signWithPassword` method to the PIN keyboard (for example, to be triggered when a sufficiently long PIN code is entered by the user).
 
-Note that the method in our example uses an `IMyAuthListener` interface. This is a placeholder interface example, you should implement your own interface that will allow you to process the authentication result asynchronously, including handling the biometry results and the entire networking cycle.
+Note that the method in our example uses an `IMyAuthListener` interface. This is a placeholder interface example, you should implement your own interface that will allow you to process the authentication result asynchronously, including handling the biometric results and the entire networking cycle.
 
 On the networking layer, we used a similar `IMyHttpClientListener` placeholder interface, you should handle the following business logic when calling the PowerAuth protected resources:
 
-- In case the HTTP status is `401` or `403`, it means that the transaction signing failed and in such case, you can simply restart the loop of checking the activation status, displaying the failure count, etc.
+- In case the HTTP status is `401` or `403`, it means that the transaction signing failed, and in such a case, you can simply restart the loop of checking the activation status, displaying the failure count, etc.
 - In case the HTTP status is `200`, it means that the transaction signing was successful. You can retrieve any data that you need from the response and close the PIN keyboard (ideally, with some nice "victory animation").
 
 

--- a/docs/tutorials/Mobile-First-Authentication/Readme.md
+++ b/docs/tutorials/Mobile-First-Authentication/Readme.md
@@ -17,15 +17,15 @@ This tutorial has five parts:
 
 ## Problem Overview
 
-Authentication is a process of verifying the user's identity. It is usually performed to manage access to an application (login) or in order to approve a transaction, such as payment, using a reliable user identity proof. In case of the banking systems, managing access to systems and transaction signing are two critical requirements from both security and compliance perspective.
+Authentication is a process of verifying the user's identity. It is usually performed to manage access to an application (login) or in order to approve a transaction, such as payment, using a reliable user identity proof. In the case of banking systems, managing access to systems and transaction signing are two critical requirements from both a security and compliance perspective.
 
-In the terms of the security, a well-designed authentication and operation approval system improves the confidentiality of the financial information, since only the correct users can access the particular account information. At the same time, it prevents money loss by protecting the financial transactions from being manipulated, since each payment has a strong cryptographic proof (such that cannot be forged, replayed, or connected to other transaction) of the user who approved it.
+In the terms of the security, a well-designed authentication and operation approval system improves the confidentiality of the financial information, since only the correct users can access the particular account information. At the same time, it prevents money loss by protecting the financial transactions from being manipulated, since each payment has a strong cryptographic proof (that cannot be forged, replayed, or connected to other transaction) of the user who approved it.
 
-In the terms of the compliance, these mechanisms are required for example to comply with the European PSD3 legislation and its requirements on Strong Customer Authentication (SCA).
+In terms of compliance, these mechanisms are required, for example, to comply with the European PSD3 legislation and its requirements on Strong Customer Authentication (SCA).
 
-Last but not least, correctly designed cryptographic protocol for authentication usually improves the user experience, since the users can login or approve a payment with a simple PIN code instead of a long password, or with a biometric authentication.
+Last but not least, a correctly designed cryptographic protocol for authentication usually improves the user experience, since the users can log in or approve a payment with a simple PIN code instead of a long password, or with biometric authentication.
 
-[Mobile-First Authentication](https://www.wultra.com/products/mobile-first-authentication) is a solution (plugin or a white-label app) for iOS and Android that - together with its server counterparts - covers the authentication and transaction signing functionality, allowing the end-users to login or approve payments using PIN code or biometry. It also covers all related use-cases, such as authentication element lifecycle (active, blocked, removed), PIN code change, biometry settings, etc. It uses [an open-source cryptographic PowerAuth protocol](/components/powerauth-crypto) that is trusted by leading banks and financial institutions to back the authentication-related processes with strong cryptography.
+[Mobile-First Authentication](https://www.wultra.com/products/mobile-first-authentication) is a solution (plugin or a white-label app) for iOS and Android that, together with its server counterparts, covers the authentication and transaction signing functionality, allowing the end-users to log in or approve payments using PIN code or biometry. It also covers all related use-cases, such as authentication element lifecycle (active, blocked, removed), PIN code change, biometry settings, etc. It uses [an open-source cryptographic PowerAuth protocol](/components/powerauth-crypto) that is trusted by leading banks and financial institutions to back the authentication-related processes with strong cryptography.
 
 
 ## Device Registration
@@ -34,7 +34,7 @@ When a user downloads a mobile app for iOS or Android, this app is always a blan
 
 The registration can be either performed fully on the mobile device (it is both initiated and completed on the mobile device), or in an "out-of-band" mode (initiated externally, for example, in the Internet banking, and completed both on the mobile device and in the external systems that initiated the activation).
 
-While the back-end system supports using flexible methods of registration using custom credentials (verified against a provided service), we recommend designing the registration flow so that is always uses an **Activation Code**. Activation code is a temporary one-time credential issued by our system whenever your systems ask for it and assigned to a user ID for whom the registration should be carried out.
+While the back-end system supports using flexible methods of registration using custom credentials (verified against a provided service), we recommend designing the registration flow so that it always uses an **Activation Code**. Activation code is a temporary one-time credential issued by our system whenever your systems ask for it and assigned to a user ID for whom the registration should be carried out.
 
 ### On-Device Registration
 
@@ -42,9 +42,9 @@ The high-level overview of the on-device registration steps is captured in this 
 
 ![ Registration - Fully on the mobile device ](./01a.png)
 
-As you can see, this diagram is relatively simple and straight-forward.
+As you can see, this diagram is relatively simple and straightforward.
 
-The first thing the mobile app has to do is to authenticate the user with some existing means of verification. It can be standard credentials, such as the username and password, or it can be an identity proofing step (scanning personal ID, server-side facial biometrics, etc.) Based on the verification, authentication back-end issues a user-specific activation code to the mobile app (while setting auto-commit mode), and the mobile app can then enrol using the activation code.
+The first thing the mobile app has to do is to authenticate the user with some existing means of verification. It can be standard credentials, such as the username and password, or it can be an identity proofing step (scanning personal ID, server-side facial biometrics, etc.) Based on the verification, the authentication back-end issues a user-specific activation code to the mobile app (while setting auto-commit mode), and the mobile app can then enroll using the activation code.
 
 ### Out-of-Band Activation
 
@@ -52,18 +52,18 @@ The high-level overview of the out-of-band activation steps is captured in this 
 
 ![ Activation - In out-of-band mode ](./01b.png)
 
-While this diagram seems a bit more complex, the process is still very simple. The main difference is in the initiation of the process, where some external system, in our case the Internet banking, must fetch and display the activation code (usually represented by a QR code, link with the parameter, or a text value). Later in the process, the Internet banking must also confirm the activation in order to make it useable on the just activated device.
+While this diagram seems a bit more complex, the process is still very simple. The main difference is in the initiation of the process, where some external system, in our case the Internet banking, must fetch and display the activation code (usually represented by a QR code, link with the parameter, or a text value). Later in the process, the Internet banking must also confirm the activation in order to make it usable on the just-activated device.
 
 ## Transaction Signing
 
 After the user activates the mobile app, it is ready for its main use case: **Transaction signing**.
 
-The transaction signing is technically used for all types of operations - login, payments, configuration changes, etc. In all cases, the user needs to enter a PIN code set during the activation, or use biometrics on the mobile device to compute an authentication code for the data. The authentication code is later verified on the server-side.
+The transaction signing is technically used for all types of operations - login, payments, configuration changes, etc. In all cases, the user needs to enter a PIN code set during activation or use biometrics on the mobile device to compute an authentication code for the data. The authentication code is later verified on the server side.
 
-In the case of the login, the authentication code is computed only from the authentication factor keys. In the case of the payment (or other similar operation that generally has some data assigned to it), both authentication factor keys and operation data is reflected in the resulting authentication code.
+In the case of the login, the authentication code is computed only from the authentication factor keys. In the case of the payment (or other similar operation that generally has some data assigned to it), both authentication factor keys and operation data are reflected in the resulting authentication code.
 
 <!-- begin box info -->
-The PSD3 legislation uses the term "dynamic linking" for this dependency of the authentication code on the operation data. PSD3 mandates using at least the other party account number, own account number and a payment amount as data that enters the authentication code, and the use of at least two authentication factors.
+The PSD3 legislation uses the term "dynamic linking" for this dependency of the authentication code on the operation data. PSD3 mandates using at least the other party's account number, own account number, and a payment amount as data that enters the authentication code, and the use of at least two authentication factors.
 <!-- end -->
 
 The number of authentication attempts is limited. If the authentication code verification fails, the number of remaining accounts is decremented. If there are no more attempts left, the registration is blocked.
@@ -80,7 +80,7 @@ The overview diagram of the transaction signing for payment approval is not much
 
 ![ Payment approval ](./02b.png)
 
-The main difference is that after a successful authentication code verification, the payment is sent for the further processing after being approved by given user. The invisible difference is that the authentication code is computed using the payment data.
+The main difference is that after a successful authentication code verification, the payment is sent for further processing after being approved by the given user. The invisible difference is that the authentication code is computed using the payment data.
 
 ## Other Use-Cases
 

--- a/docs/tutorials/Mobile-First-Authentication/iOS-Tutorial.md
+++ b/docs/tutorials/Mobile-First-Authentication/iOS-Tutorial.md
@@ -51,10 +51,9 @@ platform :ios, '11.0'
 target '<Your Target App>' do
   pod 'PowerAuth2'
 end
+```
 {% endcodetab %}
 {% endcodetabs %}
-
-_Note: You need to disable bitcode for PowerAuth SDK to work._
 
 After you made the necessary changes in the Podfile, you can run the install command:
 
@@ -125,7 +124,7 @@ Luckily, we have a simple method to obtain a detailed activation status:
 // Check if there is some activation data on the device
 if powerAuth.hasValidActivation() {
     // If there is an activation on the device, check the status with the server
-    powerAuth.fetchActivationStatus { [weak self] status, error in
+    powerAuth.fetchActivationStatus { status, error in
         // If no error occurred, process the status
         if error == nil {
             // Show the UI relevant to the activation status.
@@ -324,7 +323,7 @@ For the `.active` status, you should check if the number of failed attempts is g
 // Check if there is some activation data on the device
 if powerAuth.hasValidActivation() {
     // If there is an activation on the device, check the status with the server
-    powerAuth.fetchActivationStatus() { status, error in
+    powerAuth.fetchActivationStatus { status, error in
         // If no error occurred, process the status
         if error == nil {
             if status.state == .active {

--- a/docs/tutorials/Mobile-First-Authentication/iOS-Tutorial.md
+++ b/docs/tutorials/Mobile-First-Authentication/iOS-Tutorial.md
@@ -15,11 +15,11 @@ This tutorial has four parts:
 
 ## Prerequisites
 
-This tutorial assumes, that you have:
+This tutorial assumes that you have:
 
 - Read and understood the [Mobile Authentication Overview](Readme.md)
 - [Required back-end infrastructure up and running](Server-Side-Tutorial.md).
-- Xcode 11.4+ with the Developer Tools installed
+- Latest Xcode with the Developer Tools installed
 
 ## Introduction
 
@@ -28,36 +28,29 @@ When implementing the authentication flow on mobile, your task consists of build
 - Device activation
 - Transaction signing
 
-Of course, you will need to also implement several auxiliary use-cases but these will become simple once you have device activation and transaction signing use-cases in place.
+Of course, you will also need to implement several auxiliary use-cases, but these will become simple once you have device activation and transaction signing use-cases in place.
 
-Our [Mobile Security Suite SDK](https://wultra.com/mobile-security-suite) will help you with the above-mentioned use-cases. Since the underlying authentication protocol is called PowerAuth, the Mobile Security Suite SDK technical components inherit this naming. The "Mobile Security Suite SDK" is called the **PowerAuth SDK** on the technical level.
+Our [Mobile Security Suite SDK](https://wultra.com/mobile-security-suite) will help you with the above-mentioned use cases. Since the underlying authentication protocol is called PowerAuth, the Mobile Security Suite SDK technical components inherit this naming. The "Mobile Security Suite SDK" is called the **PowerAuth SDK** on the technical level.
 
 During the device activation flow, the SDK communicates with the public enrollment services. During the transaction signing, the SDK communicates with your server that publishes some protected resources (login, payment approval). The mobile app never communicates with the PowerAuth Server interface since this component is hidden deep in the secure infrastructure. See the component description in the [introductory overview documentation](Readme.md).
 
 ## Getting the SDK
 
-The easiest way to install the PowerAuth SDK into your project is using [Cocoapods](https://cocoapods.org/), by editing your Podfile:
+The easiest way to install the PowerAuth SDK into your project is by using Swift Package Manager. You can simply add the following dependency via Xcode:
+
+```
+https://github.com/wultra/powerauth-mobile-sdk-spm.git
+```
+
+Also popular option are [Cocoapods](https://cocoapods.org/). Add PowerAuth by editing your Podfile:
 
 {% codetabs %}
 {% codetab Podfile %}
 ```rb
-platform :ios, '8.0'
+platform :ios, '11.0'
 target '<Your Target App>' do
   pod 'PowerAuth2'
 end
-
-# Disable bitcode for iOS targets
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    if target.platform_name == :ios
-      puts "Disabling bitcode for target  #{target.name}"
-      target.build_configurations.each do |config|
-        config.build_settings['ENABLE_BITCODE'] = 'NO'
-      end
-    end
-  end
-end
-```
 {% endcodetab %}
 {% endcodetabs %}
 
@@ -87,10 +80,8 @@ import PowerAuth2
 
 To configure your `PowerAuthSDK` instance, you need the following values from the PowerAuth Server:
 
-- `APP_KEY` - Application key that binds an activation with a specific application.
-- `APP_SECRET` - Application secret that binds an activation with a specific application.
-- `KEY_MASTER_SERVER_PUBLIC` - Master Server Public Key used for non-personalized encryption and server signature verification.
-- `BASE_ENDPOINT_URL` - The location of your [PowerAuth Standard RESTful API](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Standard-RESTful-API.md) endpoints. The path should contain everything that goes before the `/pa/**` prefix of the API endpoints.
+- `MOBILE_SDK_CONFIG ` - Base64 string with the cryptographic configuration.
+- `BASE_ENDPOINT_URL` - The location of your [PowerAuth Standard RESTful API](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Standard-RESTful-API.md) endpoints. The path should contain everything that goes before the `/pa/**` prefix of the API endpoints (usually _https://***/enrollment-server_)
 
 All these values should be provided to you by your [server-side team](Server-Side-Tutorial.md) who configured the back-end infrastructure.
 
@@ -102,15 +93,15 @@ Use the provided values to configure the `PowerAuthSDK` instance:
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
     // Prepare the configuration
-    let configuration = PowerAuthConfiguration()
-    configuration.instanceId = Bundle.main.bundleIdentifier ?? ""
-    configuration.appKey = "sbG8gd...MTIzNA=="
-    configuration.appSecret = "aGVsbG...MTIzNA=="
-    configuration.masterServerPublicKey = "MTIzNDU2Nz...jc4OTAxMg=="
-    configuration.baseEndpointUrl = "https://localhost:8080/demo-server"
+    let configuration = PowerAuthConfiguration(
+        instanceId: Bundle.main.bundleIdentifier ?? "instance",
+        baseEndpointUrl: "https://<your-domain>/enrollment-server",
+        configuration: "MTIzNDU2Nz...jc4OTAxMg=="
+    )
 
     // Configure default PowerAuthSDK instance
-    PowerAuthSDK.initSharedInstance(configuration)
+    // note that if the configuration is invalid, nil is returned
+    let powerAuth = PowerAuthSDK(configuration: configuration)
 
     return true
 }
@@ -124,17 +115,17 @@ In case you use a development infrastructure with self-signed certificates, make
 
 ## Checking the Activation Status
 
-After a user launches an application, you need to determine which user interface to show. Should you display a login UI? Or a new activation flow? Or an information that the device is blocked or removed?
+After a user launches an application, you need to determine which user interface to show. Should you display a login UI? Or a new activation flow? Or is an information that the device is blocked or removed?
 
-Luckily, we have a simple method calls to obtain a detailed activation status:
+Luckily, we have a simple method to obtain a detailed activation status:
 
 {% codetabs %}
 {% codetab Swift %}
 ```swift
 // Check if there is some activation data on the device
-if PowerAuthSDK.sharedInstance().hasValidActivation() {
-    // If there is an activation on the device, check the status with server
-    PowerAuthSDK.sharedInstance().fetchActivationStatus() { (status, customObject, error) in
+if powerAuth.hasValidActivation() {
+    // If there is an activation on the device, check the status with the server
+    powerAuth.fetchActivationStatus { [weak self] status, error in
         // If no error occurred, process the status
         if error == nil {
             // Show the UI relevant to the activation status.
@@ -145,7 +136,7 @@ if PowerAuthSDK.sharedInstance().hasValidActivation() {
         }
     }
 } else {
-    // No activation is present on device.
+    // No activation is present on the device.
     // Show the UI for a new activation.
     self.presentNewActivationUi()
 }
@@ -161,13 +152,13 @@ Here is an example mockup of the screens that need to be implemented:
 
 ## New Activation
 
-In the case no usable activation is available on the iOS device, you can guide the user through the steps to create it. Each activation has two major flows on the mobile device:
+In the case that no usable activation is available on the iOS device, you can guide the user through the steps to create it. Each activation has two major flows on the mobile device:
 
 - **Creating the Activation** - Exchanging the user's identity proof with the server for the cryptographic activation data.
-- **Committing the Activation** - Storing the cryptographic activation data on the device using the user's local credentials.
+- **Persisting the Activation** - Storing the cryptographic activation data on the device using the user's local credentials.
 
 <!-- begin box info -->
-Thanks to the commit step, the user credentials, such as PIN code or biometric information, never leave the mobile device and are only used locally, to obtain cryptographic data required during the transaction signing.
+Thanks to the persist step, the user credentials, such as PIN code or biometric information, never leave the mobile device and are only used locally to obtain cryptographic data required during the transaction signing.
 <!-- end -->
 
 ### Creating the Activation
@@ -185,25 +176,28 @@ The easiest way to create an activation is using the PowerAuth activation code t
 let deviceName = UIDevice.current.name
 let activationCode = "VVVVV-VVVVV-VVVVV-VTFVA"
 
-// Create activation object with given activation code.
-guard let activation = PowerAuthActivation(activationCode: activationCode, name: deviceName) else {
-    // Activation code is invalid
+do {
+    // Create activation object with given activation code.
+    let activation = try PowerAuthActivation(activationCode: activationCode, name: deviceName)
+    
+    // Create a new activation with just the newly created activation object
+    powerAuth.createActivation(activation) { result, error in
+        if error == nil {
+            // No error occurred, proceed to credentials entry (PIN prompt, Enable Touch ID switch, ...) and persist
+        } else {
+            // An error occurred, report it to the user
+        }
+    }
+} catch let error {
+    // process error
 }
 
-// Create a new activation with just created activation object
-PowerAuthSDK.sharedInstance().createActivation(activation) { (result, error) in
-    if error == nil {
-        // No error occurred, proceed to credentials entry (PIN prompt, Enable Touch ID switch, ...) and commit
-    } else {
-        // An error occurred, report it to the user
-    }
-}
 ```
 {% endcodetab %}
 {% endcodetabs %}
 
 <!-- begin box info -->
-You can let the user scan the activation code from a QR code, to make the process faster and improve the user convenience, but you should also allow the manual entry as a backup.
+You can let the user scan the activation code from a QR code to make the process faster and improve user convenience, but you should also allow manual entry as a backup.
 <!-- end -->
 
 ##### Mockups
@@ -221,7 +215,7 @@ However, once you have the credentials that are sufficiently strong, you can cre
 {% codetabs %}
 {% codetab Swift %}
 ```swift
-// Create a new activation with given device name and custom login credentials
+// Create a new activation with the given device name and custom login credentials
 let deviceName = UIDevice.current.name
 let credentials = [
     "username": "john.doe@example.com",
@@ -229,24 +223,26 @@ let credentials = [
     "otp": "072471"
 ]
 
-// Create activation object with given credentials.
-guard let activation = PowerAuthActivation(identityAttributes: credentials, name: deviceName) else {
-    // Activation credentials are empty
-}
-
-// Create a new activation with just created activation object
-PowerAuthSDK.sharedInstance().createActivation(activation) { (result, error) in
-    if error == nil {
-        // No error occurred, proceed to credentials entry (PIN prompt, Enable Touch ID switch, ...) and commit
-    } else {
-        // Error occurred, report it to the user
+do {
+    // Create activation object with given credentials.
+    let activation = try PowerAuthActivation(identityAttributes: credentials, name: deviceName)
+    
+    // Create a new activation with just the newly created activation object
+    powerAuth.createActivation(activation) { result, error in
+        if error == nil {
+            // No error occurred, proceed to credentials entry (PIN prompt, Enable Touch ID switch, ...) and persist
+        } else {
+            // Error occurred, report it to the user
+        }
     }
+} catch let error {
+    // process error
 }
 ```
 {% endcodetab %}
 {% endcodetabs %}
 
-In the example, we used a combination of the username, password and an OTP generated elsewhere (for example, via a HW token, or delivered via SMS). But any credentials that you determined are suitable for activation will work.
+In the example, we used a combination of the username, password, and an OTP generated elsewhere (for example, via a hardware token or delivered via SMS). But any credentials that you determined are suitable for activation will work.
 
 ##### Mockups
 
@@ -254,49 +250,47 @@ Here is an example mockup of the screens that need to be implemented:
 
 ![ Activation Status Check on iOS ](./05.png)
 
-### Committing the Activation
+### Persisting the Activation
 
-After you successfully perform the steps for creating the activation, you can prompt the user to enter the new local PIN code / password and allow an opt-in for the biometric authentication (of course, [only in the case the device supports biometry](https://github.com/wultra/powerauth-mobile-sdk/blob/develop/docs/PowerAuth-SDK-for-iOS.md#biometry-setup)).
+After you successfully perform the steps for creating the activation, you can prompt the user to enter the new local PIN code / password and allow an opt-in for the biometric authentication (of course, [only in the case the device supports biometrics](https://github.com/wultra/powerauth-mobile-sdk/blob/develop/docs/PowerAuth-SDK-for-iOS.md#biometry-setup)).
 
-You can now commit the newly created activation with the requested authentication factors:
+You can now persist the newly created activation with the requested authentication factors:
 
 {% codetabs %}
 {% codetab Swift %}
 ```swift
 do {
-    let auth = PowerAuthAuthentication()
-    auth.usePossession = true
-    auth.usePassword   = "1234" // user's PIN code
-    auth.useBiometry   = true
+    let password = PowerAuthCorePassword(string: "1234")
+    let auth = PowerAuthAuthentication.persistWithPasswordAndBiometry(password: password)
 
-    try PowerAuthSDK.sharedInstance().commitActivation(with: auth)
+    try powerAuth.persistActivation(with: auth)
 } catch _ {
-    // happens only in case SDK was not configured or
-    // when activation is not in the correct state to be committed
+    // happens only in case the SDK was not configured or
+    // when activation is not in the correct state to be persisted
 }
 ```
 {% endcodetab %}
 {% endcodetabs %}
 
-In most cases, the `usePossession` is set to `true` and `usePassword` to the value of the PIN or password user selected. The `useBiometry` value should be set to `true` in the case user decided to opt-in for biometric authentication, and to `false` otherwise.
+If User user opted out of using biometrics, you can simply use `PowerAuthAuthentication.persistWithPassword`.
 
 ## Transaction Signing
 
 In case you successfully activated the device, you can use the new activation for transaction signing. This is achieved by signing the full request data. In case of the HTTP request with a body (`POST`, `PUT`, `DELETE`), the HTTP request body is used. In case of the `GET` request, the SDK builds canonical data from the URL query parameters.
 
-The transaction signing requires an absolute precision. Every single bit makes a huge difference just one step further in the process. Be patient and do not worry if transaction signing doesn't work the first time you try. In case you are having issues, do not hesitate to ask our engineers for help.
+The transaction signing requires absolute precision. Every single bit makes a huge difference, just one step further in the process. Be patient and do not worry if transaction signing doesn't work the first time you try. In case you are having issues, do not hesitate to ask our engineers for help.
 
 ### User Experience Perspective
 
-To make the user experience consistent, we recommend making a solid UI abstraction on top of the transaction signing logic. This usually means implementing the transaction signing logic inside a **unified PIN keyboard**. Such keyboard would then handle the typical use-cases people expect to see when working with PIN keyboards, such as:
+To make the user experience consistent, we recommend making a solid UI abstraction on top of the transaction signing logic. This usually means implementing the transaction signing logic inside a **unified PIN keyboard**. Such a keyboard would then handle the typical use-cases people expect to see when working with PIN keyboards, such as:
 
 - Entering a PIN code for the purpose of transaction signing.
-- Allowing to use biometry as a faster alternative to the PIN code.
+- Allowing to use of biometrics as a faster alternative to the PIN code.
 - Checking the number of remaining authentication attempts.
 - Showing the transaction signing progress.
 - Error reporting, invalid activation status handling, etc.
 
-The following picture shows an anatomy of a well-designed PIN keyboard:
+The following picture shows the anatomy of a well-designed PIN keyboard:
 
 ![ Anatomy of a PIN keyboard ](./06.png)
 
@@ -310,27 +304,27 @@ You can read more information about the authentication flow in the chapters belo
 
 To cover the typical use-cases efficiently, the unified PIN keyboard should be configurable with at least the following attributes:
 
-- **The URI Address** - Basically the service location that will be called while sending the signed request using an HTTP client of your choice. We use `uri` variable in the example.
+- **The URI Address** - Basically, the service location that will be called while sending the signed request using an HTTP client of your choice. We use the `uri` variable in the example.
 - **The URI ID** - Identifier of the URI / service. **Be very careful here!** In the examples below, we use a value of `uriId` for this value. While it is remarkably similar to the end of an actual URI (`uri`), this value is in fact an arbitrarily chosen constant that the client and server must agree on beforehand for a particular server-side operation represented. You need to ask your server developer for the exact value.
 - **The HTTP request data** - This is basically the data that will be signed. For the `POST` requests (that are the most common in the case of transaction signing), this value represents simply the HTTP request body bytes.
-- **The HTTP method** - (Optional) The HTTP method to be used for the call. For the most cases, the calls should be made via the `POST` value and hence the `POST` value should be the default.
+- **The HTTP method** - (Optional) The HTTP method to be used for the call. In most cases, the calls should be made via the `POST` value, and hence, the `POST` value should be the default.
 - **The HTTP headers** - (Optional) Value of any other HTTP headers you need to use when calling your service.
 
 ### Checking the Activation Status Before Signing
 
-We covered a similar use-case earlier in the context of the new activation flow. However, you should also check for the activation status before every attempt to use the transaction signing since the activation might have been blocked or removed on the server side.
+We covered a similar use case earlier in the context of the new activation flow. However, you should also check for the activation status before every attempt to use the transaction signing, since the activation might have been blocked or removed on the server side.
 
 In case you check the activation status and the result is anything else than `.active`, you should cancel the transaction signing flow and redirect the user to the appropriate alternate flow, such as a new activation wizard, unblocking tutorial, etc.
 
-For the `.active` status, you should check if the number of failed attempts is greater than zero and show the UI for the number of remaining attempts in such case. The outline of the logic is the following:
+For the `.active` status, you should check if the number of failed attempts is greater than zero, and show the UI for the number of remaining attempts in such a case. The outline of the logic is the following:
 
 {% codetabs %}
 {% codetab Swift %}
 ```swift
 // Check if there is some activation data on the device
-if PowerAuthSDK.sharedInstance().hasValidActivation() {
-    // If there is an activation on the device, check the status with server
-    PowerAuthSDK.sharedInstance().fetchActivationStatus() { (status, customObject, error) in
+if powerAuth.hasValidActivation() {
+    // If there is an activation on the device, check the status with the server
+    powerAuth.fetchActivationStatus() { status, error in
         // If no error occurred, process the status
         if error == nil {
             if status.state == .active {
@@ -351,7 +345,7 @@ if PowerAuthSDK.sharedInstance().hasValidActivation() {
         }
     }
 } else {
-    // No activation is present on device.
+    // No activation is present on the device.
     // Show the UI for a new activation.
     self.presentNewActivationUi()
 }
@@ -368,11 +362,11 @@ To check the status of the biometry, you can use the following logic:
 {% codetabs %}
 {% codetab Swift %}
 ```swift
-if PA2Keychain.canUseBiometricAuthentication && status.remainingAttempts > 2 && self.autoTriggerBiometry {
+if PowerAuthKeychain.canUseBiometricAuthentication && status.remainingAttempts > 2 && self.autoTriggerBiometry {
     self.biometryButton.enabled = true
     self.signWithBiometry()
 } else {
-    // Let user enter PIN code
+    // Let the user enter the PIN code
     self.biometryButton.enabled = false
 }
 self.autoTriggerBiometry = false
@@ -380,7 +374,7 @@ self.autoTriggerBiometry = false
 {% endcodetab %}
 {% endcodetabs %}
 
-Note that decided to not only check for the mere availability of the biometry, but we also check for the remaining attempt count to make sure the user is not blocked in case of "wet fingers". Also, you can notice the property `autoTriggerBiometry` that we use to automatically launch the biometry only the first time a unified PIN keyboard is opened. For 2nd and further authentication attempts, we want the user to trigger the biometric authentication manually.
+Note that we decided to not only check for the mere availability of the biometry, but we also check for the remaining attempt count to make sure the user is not blocked in case of "wet fingers". Also, you can notice the property `autoTriggerBiometry` that we use to automatically launch the biometry only the first time a unified PIN keyboard is opened. For 2nd and further authentication attempts, we want the user to trigger the biometric authentication manually.
 
 ### Request Signing
 
@@ -389,19 +383,15 @@ To sign the request data, you first need to prepare a `PowerAuthAuthentication` 
 {% codetabs %}
 {% codetab Swift %}
 ```swift
-// Transaction signing with a biometry
+// Transaction signing with biometrics
 func signWithBiometry() -> URLSessionDataTask? {
-    let auth = PowerAuthAuthentication()
-    auth.usePossession = true
-    auth.useBiometry   = true
+    let auth = PowerAuthAuthentication.possessionWithBiometry()
     return signWith(authentication: auth)
 }
 
 // Transaction signing with a password or a PIN code
 func signWith(password: String) -> URLSessionDataTask? {
-    let auth = PowerAuthAuthentication()
-    auth.usePossession = true
-    auth.usePassword   = password
+    let auth = PowerAuthAuthentication.possessionWithPassword(password: PowerAuthCorePassword(password: password))
     return signWith(authentication: auth)
 }
 
@@ -412,10 +402,10 @@ func signWith(authentication: PowerAuthAuthentication) -> URLSessionDataTask? {
         let uri    = self.uri    // "https://my.server.example.com/payment"
         let uriId  = self.uriId  // "/payment"
         let method = self.method // "POST"
-        let body   = self.body   // the serialized bytes of HTTP request body
+        let body   = self.body   // the serialized bytes of the HTTP request body
 
         // Compute the signature header
-        let signature = try PowerAuthSDK.sharedInstance().requestSignature(with: auth, method: method, uriId: uriId, body: body)
+        let signature = try powerAuth.requestSignature(with: auth, method: method, uriId: uriId, body: body)
         let header = [ signature.key: signature.value ]
 
         // Send an HTTP request with the HTTP header computed above.
@@ -436,7 +426,7 @@ You can hook the `signWithBiometry` method to the button for the biometric authe
 
 Note that the method in our example returns an `URLSessionDataTask` instance (of course, this could be any networking abstraction you use in your project), or a `nil` value in case there is an invalid state. In case the `URLSessionDataTask` is launched, you should wait for it to complete (showing the progress indicator to the user) and check the response HTTP status:
 
-- In case the HTTP status is `401` or `403`, it means that the transaction signing failed and in such case, you can simply restart the loop of checking the activation status, displaying the failure count, etc.
+- In case the HTTP status is `401` or `403`, it means that the transaction signing failed, and in such a case, you can simply restart the loop of checking the activation status, displaying the failure count, etc.
 - In case the HTTP status is `200`, it means that the transaction signing was successful. You can retrieve any data that you need from the response and close the PIN keyboard (ideally, with some nice "victory animation").
 
 

--- a/docs/tutorials/Mobile-First-Authentication/iOS-Tutorial.md
+++ b/docs/tutorials/Mobile-First-Authentication/iOS-Tutorial.md
@@ -109,7 +109,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 {% endcodetabs %}
 
 <!-- begin box warning -->
-In case you use a development infrastructure with self-signed certificates, make sure to set `PA2ClientSslNoValidationStrategy` to the shared SDK instance and check the transport security configuration in your `Info.plist` file.
+In case you use a development infrastructure with self-signed certificates, make sure to set `PA2ClientSslNoValidationStrategy` to the SDK instance and check the transport security configuration in your `Info.plist` file.
 <!-- end -->
 
 ## Checking the Activation Status


### PR DESCRIPTION
Fixed issues (deprecated APIs, old naming, unsupported install options, etc) in the mobile part of the tutorial.

Also, rewritten Java example 👴 to Kotlin 🍭 